### PR TITLE
[EPIC-01][EPIC-02] Fix analytics data source and reflection modal scroll

### DIFF
--- a/src/components/trades/TradeReflectionModal.js
+++ b/src/components/trades/TradeReflectionModal.js
@@ -121,7 +121,7 @@ export default function TradeReflectionModal({ trade, open, onClose }) {
           </p>
         </DialogHeader>
 
-        <div className="overflow-y-auto flex-1 space-y-6 pr-1">
+        <div className="overflow-y-auto space-y-6 pr-1" style={{ maxHeight: "calc(90vh - 200px)" }}>
           {/* Trade Summary — read-only; all values backend-sourced (spec §4) */}
           <div className="rounded-xl bg-slate-800/60 border border-slate-700/50 p-4">
             <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">

--- a/src/pages/PerformanceAnalytics.js
+++ b/src/pages/PerformanceAnalytics.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { base44 } from "../api/base44Client";
+import { api } from "../api/base44Client";
 import PageHeader from "../components/ui/PageHeader";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
 import { AlertCircle, Loader2, Download } from "lucide-react";
@@ -40,20 +40,19 @@ const toCamelCase = (obj) => {
 export default function PerformanceAnalytics() {
   const [timePeriod, setTimePeriod] = useState("last_month");
 
-  const { data: settings } = useQuery({
+  const { data: settingsRaw } = useQuery({
     queryKey: ["settings"],
-    queryFn: () => base44.entities.Settings.list(),
+    queryFn: () => api.settings.list(),
     initialData: [],
   });
 
-  const { data: positions, isLoading } = useQuery({
-    queryKey: ["positions"],
-    queryFn: () => base44.entities.Position.list("-exit_date"),
-    initialData: [],
+  const { data: tradesData, isLoading } = useQuery({
+    queryKey: ["trades"],
+    queryFn: () => api.trades.list(),
   });
 
-  const settingsData = settings?.[0] || { min_trades_for_analytics: 10 };
-  const closedTrades = positions.filter(p => p.status === "closed");
+  const settingsData = (Array.isArray(settingsRaw) ? settingsRaw[0] : settingsRaw?.data?.[0]) || { min_trades_for_analytics: 10 };
+  const closedTrades = tradesData?.trades ?? (Array.isArray(tradesData) ? tradesData : []);
 
   // Filter by time period
   const getFilteredTrades = () => {


### PR DESCRIPTION
## Summary

- **`src/pages/PerformanceAnalytics.js`** — switched trade data source from `base44.entities.Position.list()` (`GET /positions`, then filtering `p.status === "closed"`) to `api.trades.list()` (`GET /trades`). Root cause: `/positions` uses uppercase status values (`"CLOSED"`) so the lowercase equality check always returned 0 trades, causing the analytics page to show "Not Enough Data" regardless of threshold. `/trades` is the canonical trade history endpoint (same source used by `TradeHistory.js`).

- **`src/components/trades/TradeReflectionModal.js`** — replaced `flex-1 overflow-y-auto` (which relies on `flex-1` growing against a `max-h` parent — unreliable across browsers) with a direct `maxHeight: calc(90vh - 200px)` inline style on the scroll container. Scroll now engages reliably regardless of flex layout context.

## Test plan

- [ ] Analytics page loads with trade data (not "Not Enough Data" screen) when closed trades exist
- [ ] R-multiple distribution chart renders
- [ ] Discipline & Compliance section renders (shows "—" if no entry/exit notes)
- [ ] Trade Reflection modal: all 5 reflection fields visible and scrollable
- [ ] Trade Reflection modal: Save button visible at bottom

⚠️ **Human QA sign-off required before merge** — per governance rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)