### PR TITLE
[EPIC-01] Fix DisciplineComplianceSection double-unwrap of API response

### DIFF
--- a/src/components/analytics/DisciplineComplianceSection.js
+++ b/src/components/analytics/DisciplineComplianceSection.js
@@ -42,7 +42,7 @@ export default function DisciplineComplianceSection({ period }) {
     retry: 1,
   });
 
-  const metrics = data?.data;
+  const metrics = data;
   const tradeCount = metrics?.trade_count ?? 0;
   const noData = tradeCount === 0;
 


### PR DESCRIPTION
## Summary

`DisciplineComplianceSection.js` had `const metrics = data?.data` — but `doFetch` already unwraps the `{ status, data }` API envelope, so `data` is the metrics object directly. The double-unwrap produced `undefined`, making `tradeCount = 0` and all three compliance cards show `"—"`.

**Fix:** `const metrics = data` (one character change).

**Verified against live API payload:**
```json
{ "journal_completion_rate": 16.7, "stop_exit_rate": 50.0, "avg_position_size_pct": 17.45, "trade_count": 6 }
```

## Test plan
- [ ] Discipline & Compliance section shows: Journal Completion Rate 16.7%, Stop-Based Exit Rate 50.0%, Average Position Size 17.45%
- [ ] Sub-labels show "last 6 trades"

⚠️ Human QA sign-off required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)