### PR TITLE
[EPIC-01] Sync ticker universe from public.tickers at startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -22,7 +22,7 @@ from routers import ticker_universe as ticker_universe_router
 from routers import screener as screener_router
 from services.watchlist_service import ensure_watchlist_table
 from services.ai_audit_service import ensure_ai_audit_table
-from services.ticker_universe_service import ensure_ticker_universe_table, seed_default_tickers
+from services.ticker_universe_service import ensure_ticker_universe_table, seed_default_tickers, sync_from_tickers_table
 from services.screener_batch_service import ensure_screener_results_table
 
 
@@ -195,6 +195,11 @@ def on_startup():
         _log.info("ensure_ticker_universe_table: OK (seeded %d default tickers)", seeded)
     except Exception as _e:
         _log.error("ensure_ticker_universe_table FAILED at startup: %s", _e)
+    try:
+        synced = sync_from_tickers_table()
+        _log.info("sync_from_tickers_table: OK (%d tickers synced from public.tickers)", synced)
+    except Exception as _e:
+        _log.warning("sync_from_tickers_table skipped (public.tickers may not exist): %s", _e)
     try:
         ensure_screener_results_table()
         _log.info("ensure_screener_results_table: OK")

--- a/backend/services/ticker_universe_service.py
+++ b/backend/services/ticker_universe_service.py
@@ -105,6 +105,42 @@ def soft_delete_ticker(ticker: str) -> bool:
     return affected > 0
 
 
+def sync_from_tickers_table() -> int:
+    """
+    Upsert all rows from public.tickers into ticker_universe.
+    exchange='LSE' → market='UK' (ticker gets .L suffix if missing).
+    All other exchanges → market='US'.
+    Returns count of rows inserted/updated.
+    """
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT ticker, exchange FROM tickers")
+            rows = cur.fetchall()
+
+        count = 0
+        with conn.cursor() as cur:
+            for row in rows:
+                raw_ticker = row["ticker"].strip().upper()
+                exchange = (row["exchange"] or "").strip().upper()
+                if exchange == "LSE":
+                    market = "UK"
+                    ticker = raw_ticker if raw_ticker.endswith(".L") else raw_ticker + ".L"
+                else:
+                    market = "US"
+                    ticker = raw_ticker
+                cur.execute(
+                    """
+                    INSERT INTO ticker_universe (ticker, market, active)
+                    VALUES (%s, %s, TRUE)
+                    ON CONFLICT (ticker) DO UPDATE SET active = TRUE, market = EXCLUDED.market
+                    """,
+                    (ticker, market),
+                )
+                count += cur.rowcount
+        conn.commit()
+    return count
+
+
 def seed_default_tickers() -> int:
     count = 0
     for t in DEFAULT_TICKERS:


### PR DESCRIPTION
## Summary

- At startup, reads all rows from `public.tickers` and upserts them into `ticker_universe`, so the screener runs against the user's existing ticker data rather than only the 10 seeded defaults.
- `exchange = 'LSE'` → `market = 'UK'` with `.L` suffix appended; all other exchanges → `market = 'US'`.
- Non-destructive: existing `ticker_universe` entries are preserved. Gracefully skips with a warning if `public.tickers` does not exist.

**Cross-EPIC note:** EPIC-01 ST-01 code committed on EPIC-02 branch — prod hotfix, authorised by user 2026-04-28.

## Test plan

- [ ] Server restarts without error when `public.tickers` exists and is populated
- [ ] `GET /ticker-universe` returns all tickers from `public.tickers` after restart
- [ ] Server starts cleanly (warning only) when `public.tickers` does not exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)