### PR TITLE
[EPIC-01] Fix Alpaca null bars crash and hyphenated ticker symbols

### DIFF
--- a/backend/services/alpaca_service.py
+++ b/backend/services/alpaca_service.py
@@ -67,9 +67,9 @@ def get_ohlcv_bars(symbol: str, limit: int = 30, timeframe: str = "1Day") -> Opt
             resp = requests.get(url, params=params, headers=headers, timeout=10)
             if resp.status_code == 200:
                 data = resp.json()
-                bars = data.get("bars", [])
+                bars = data.get("bars") or []
                 logger.info("Alpaca bars fetched for %s: %d bars", symbol, len(bars))
-                return bars
+                return bars or None
             elif resp.status_code == 429:
                 if attempt < max_attempts:
                     time.sleep(delay)

--- a/backend/services/screener_data_service.py
+++ b/backend/services/screener_data_service.py
@@ -136,7 +136,8 @@ def fetch_ohlcv(ticker: str, market: str, days: int = 30) -> Optional[List[OHLCV
 
     if market == "US":
         t0 = _time.monotonic()
-        bars = get_ohlcv_bars(ticker, limit=days)
+        alpaca_symbol = ticker.replace("-", ".")
+        bars = get_ohlcv_bars(alpaca_symbol, limit=days)
         latency = (_time.monotonic() - t0) * 1000
         if bars:
             record_external_api_call("alpaca", True, latency)


### PR DESCRIPTION
## Summary

- **500 error fix**: `data.get("bars", [])` returned `None` when Alpaca responded with `"bars": null` (valid response for tickers with no data). Changed to `data.get("bars") or []` — prevents `TypeError: object of type 'NoneType' has no len()`.
- **BRK-B / BF-B 400 fix**: Alpaca uses `.` notation for share-class tickers (`BRK.B`, `BF.B`) but `public.tickers` stores them with `-`. Now normalises `-` → `.` before the Alpaca call only; Yahoo Finance fallback retains the original symbol.

**Cross-EPIC note:** EPIC-01 ST-04 code committed on EPIC-02 branch — prod hotfix, authorised by user 2026-04-28.

## Test plan

- [ ] `POST /screener/run` no longer returns 500
- [ ] `BRK-B`, `BF-B` and similar tickers resolve via Alpaca (`.` normalised) or fall through to Yahoo Finance
- [ ] All screener batch service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)