### PR TITLE
[GOVERNANCE] Fix signals page showing all historic signals

### DIFF
--- a/src/pages/Signals.js
+++ b/src/pages/Signals.js
@@ -167,6 +167,9 @@ export default function SignalsPage() {
     return 0;
   });
 
+  // Enforce top_n limit after all filters and sorting
+  filteredSignals = filteredSignals.slice(0, topN);
+
   // Calculate stats only for NEW signals
   const newSignals = filteredSignals.filter(s => s.status === "new");
   const totalCapital = newSignals.reduce((sum, s) => sum + (s.total_cost || 0), 0);


### PR DESCRIPTION
## Summary
- Signals page was displaying all signals returned by the backend, ignoring the Top N setting
- The backend accepts `top_n` as a query param but never enforces it — all signals are returned
- Added a client-side `slice(0, topN)` after all filters and sorting to enforce the limit

## Test plan
- [ ] Load signals page — should show at most 5 signals by default
- [ ] Change Top N input — signal count should update accordingly
- [ ] Toggle "All Days" — limit still applies across all dates
- [ ] Existing Playwright tests SC-E03-07 and SC-E03-08 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)