### PR TITLE
[GOVERNANCE] Fix research page momentum signal always showing — get_signals() wrong argument

### DIFF
--- a/backend/routers/research.py
+++ b/backend/routers/research.py
@@ -101,7 +101,7 @@ def _get_regime() -> Optional[dict]:
 
 def _get_signal(ticker: str, portfolio_id: str) -> Optional[dict]:
     try:
-        signals = get_signals(portfolio_id)
+        signals = get_signals()
         ticker_upper = ticker.upper()
         matches = [s for s in signals if (s.get("ticker") or "").upper() == ticker_upper]
         if not matches:


### PR DESCRIPTION
## Summary
- `_get_signal()` in `backend/routers/research.py` was calling `get_signals(portfolio_id)`, passing the portfolio UUID as the `status` filter argument
- `get_signals()` first parameter is `status: Optional[str]`, not `portfolio_id` — so every call filtered for signals where `status == <uuid>`, returning an empty list
- Result: `signal` was always `None` on the Research page, rendering "—" for Momentum Signal, ATR, and blocking prospective heat calculation for every ticker

## Fix
One-line change: `get_signals(portfolio_id)` → `get_signals()` — returns all signals, existing ticker-match logic then finds the correct signal.

## Test plan
- [x] Navigate to Research page for a ticker with an active signal (e.g. SNDK)
- [x] Confirm Momentum Signal badge shows correct status (not "—")
- [x] Confirm ATR value populated
- [x] Confirm Prospective Heat panel calculates (was blocked by missing entry/stop prices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)