### PR TITLE
[GOVERNANCE] Fix research page signal sort — prefer most recent signal by date

### DIFF
--- a/backend/routers/research.py
+++ b/backend/routers/research.py
@@ -106,6 +106,11 @@ def _get_signal(ticker: str, portfolio_id: str) -> Optional[dict]:
         matches = [s for s in signals if (s.get("ticker") or "").upper() == ticker_upper]
         if not matches:
             return None
+        # Prefer most recent signal by date; within same date prefer 'new' over other statuses
+        matches.sort(key=lambda x: (
+            str(x.get("signal_date") or ""),
+            0 if x.get("status") == "new" else 1
+        ), reverse=True)
         s = matches[0]
         return {
             "signal_id": str(s.get("id", "")),


### PR DESCRIPTION
## Summary
- Follow-up to #419: after fixing the `get_signals()` argument, the Research page was showing "already_held" for tickers that also had a newer "new" signal record
- `matches[0]` was returning whichever record the DB served first — often an older stale record
- Fix: sort matches by `signal_date` descending, with "new" status preferred within the same date

## Test plan
- [ ] Navigate to Research page for SNDK (or any ticker with an active signal)
- [ ] Confirm Momentum Signal badge shows "New Signal" not "already_held"
- [ ] Confirm ATR and prospective heat populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)