### PR TITLE
[GOVERNANCE] fix: replace deprecated FastAPI regex= with pattern=

### DIFF
--- a/backend/routers/analytics.py
+++ b/backend/routers/analytics.py
@@ -205,7 +205,7 @@ def _build_trades_for_charts_no_join(cursor, since_date) -> list:
 async def get_analytics_metrics(
     period: str = Query(
         "all_time",
-        regex="^(last_7_days|last_month|last_quarter|last_year|ytd|all_time)$"
+        pattern="^(last_7_days|last_month|last_quarter|last_year|ytd|all_time)$"
     )
 ):
     """
@@ -338,7 +338,7 @@ async def get_analytics_metrics(
 async def get_cohort_analysis(
     period: str = Query(
         "month",
-        regex="^(month|quarter|year)$"
+        pattern="^(month|quarter|year)$"
     )
 ):
     """


### PR DESCRIPTION
## Summary
- Replaces the deprecated `regex=` parameter with `pattern=` in two `Query()` calls in `backend/routers/analytics.py`
- Eliminates `FastAPIDeprecationWarning` on startup; `regex=` will become an error in a future Pydantic v2 minor release

## Test plan
- [ ] Restart the backend and confirm no `FastAPIDeprecationWarning` in logs
- [ ] Verify `/analytics/metrics` and `/analytics/cohort` endpoints still reject invalid `period` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)