### PR TITLE
[GOVERNANCE] Fix research price_change_pct fallback, TickerUniverse nav route, and Screener UK ticker alignment

### DIFF
--- a/backend/routers/research.py
+++ b/backend/routers/research.py
@@ -49,6 +49,10 @@ def _get_price_data(ticker: str, market: str):
         meta = result[0]["meta"]
         price = meta.get("regularMarketPrice")
         change_pct = meta.get("regularMarketChangePercent")
+        if change_pct is None:
+            prev_close = meta.get("chartPreviousClose")
+            if price and prev_close:
+                change_pct = (price - prev_close) / prev_close * 100
         if price and market == "UK":
             price = price / 100  # pence → pounds
         return {

--- a/src/pages/Screener.js
+++ b/src/pages/Screener.js
@@ -789,8 +789,6 @@ export default function Screener() {
                                     <Newspaper className="w-3 h-3" />
                                     {row.news_headline_count}
                                   </button>
-                                ) : row.market !== "US" ? (
-                                  <span className="text-slate-600 text-xs">—</span>
                                 ) : null}
 
                                 {/* Watchlist button */}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,6 +18,7 @@ export const createPageUrl = (pageName) => {
     Watchlist: '/Watchlist',
     WeeklyDigest: '/WeeklyDigest',
     Screener: '/Screener',
+    TickerUniverse: '/TickerUniverse',
   };
   return routes[pageName] || '/';
 };


### PR DESCRIPTION
## Summary

- **Research page price change** — `regularMarketChangePercent` is not populated by Yahoo Finance's v8 chart API. Added fallback: calculates `(price - chartPreviousClose) / chartPreviousClose` when the field is null, so the daily % change now displays instead of `—`.
- **Ticker Universe nav** — `TickerUniverse` was missing from the `createPageUrl` route map in `src/utils/index.js`, causing every nav click to fall back to `/` (dashboard). Added the entry.
- **Screener UK ticker button alignment** — Non-US ticker rows rendered a `—` placeholder in the news badge slot, pushing Watchlist and Research buttons out of alignment vs US rows. Removed the placeholder.

## Test plan

- [ ] Research page: load a US and UK ticker — daily % change renders with correct sign and colour
- [ ] Nav: click Ticker Universe — routes to `/TickerUniverse` not dashboard
- [ ] Screener: filter to UK tickers — Watchlist and Research buttons align with US ticker rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)