### PR TITLE
[EPIC-02] Agent Header Standardization

### DIFF
--- a/.claude_current_state.json
+++ b/.claude_current_state.json
@@ -1,7 +1,7 @@
 {
   "active_cycle": "2026-05-30__release-v4.5",
   "cycle_name": "Release Planning — v4.5 Governance Prompt Hardening, Audit Debt & SI-02 Spec Pre-Planning",
-  "status": "Sprint_Planning_Complete",
+  "status": "Executing",
   "engine": "release_planning",
   "execution_state_path": "",
   "backlog_slice_path": "claude/cycles/2026-05-30__release-v4.5/stage4_backlog_slice.md",

--- a/claude/agents/api_contracts_documentation_owner.md
+++ b/claude/agents/api_contracts_documentation_owner.md
@@ -1,5 +1,5 @@
 # API Contracts & Documentation Owner
-## Role: API Contracts & Documentation Owner
+**Role:** API Contracts & Documentation Owner
 
 This document describes the **skills, responsibilities, and operating standards** for the role responsible for owning, maintaining, and evolving the API contracts in `docs/specs/api_contracts/`.
 

--- a/claude/agents/backend_engineering_patterns_owner.md
+++ b/claude/agents/backend_engineering_patterns_owner.md
@@ -1,6 +1,6 @@
 # Backend Engineering Patterns
 
-**Owner:** Backend Engineering Patterns Owner
+**Role:** Backend Engineering Patterns Owner
 **Reports to:** Head of Engineering
 **Governance alignment:** Head of Specs Team (documentation lifecycle, document classes, headers, naming conventions)
 **Scope:** Backend implementation patterns, conventions, and engineering standards for the FastAPI / PostgreSQL codebase

--- a/claude/agents/data_model_domain_schema_owner.md
+++ b/claude/agents/data_model_domain_schema_owner.md
@@ -1,5 +1,5 @@
 # Data Model & Domain Schema Owner
-## Role: Data Model & Domain Schema Owner
+**Role:** Data Model & Domain Schema Owner
 
 This document defines the **skills, responsibilities, and operating standards** for the role responsible for owning, maintaining, and evolving the **Data Model** for the Momentum Trading Assistant.
 

--- a/claude/agents/frontend_specs_ux_documentation_owner.md
+++ b/claude/agents/frontend_specs_ux_documentation_owner.md
@@ -1,5 +1,5 @@
 # Frontend Specifications & UX Documentation Owner
-## Role: Frontend Specifications & UX Documentation Owner
+**Role:** Frontend Specifications & UX Documentation Owner
 
 This document describes the **skills, responsibilities, and operating standards** for the role responsible for owning, maintaining, and evolving the front-end specifications in `specs/frontend/`.
 

--- a/claude/agents/metrics_definitions_analytics_owner.md
+++ b/claude/agents/metrics_definitions_analytics_owner.md
@@ -1,5 +1,5 @@
 # Metrics Definitions & Analytics Canonical Owner
-## Role: Metrics Definitions & Analytics Canonical Owner
+**Role:** Metrics Definitions & Analytics Canonical Owner
 
 This document defines the **skills, responsibilities, and operating standards** for the role responsible for owning, maintaining, and evolving the **Metrics Definitions – Canonical Specification**.
 

--- a/claude/cycles/2026-05-30__release-v4.5/execution_state.json
+++ b/claude/cycles/2026-05-30__release-v4.5/execution_state.json
@@ -1,0 +1,143 @@
+{
+  "cycle_id": "2026-05-30__release-v4.5",
+  "sprint_goal": "Deliver all four v4.4 deferred execution_prompt.md governance patches and standardize agent role headers, resolving outstanding audit debt and hardening the governance infrastructure before SI-02 sprint planning begins.",
+  "backlog_slice_source": "claude/cycles/2026-05-30__release-v4.5/stage4_backlog_slice.md",
+  "invoked_utc": "2026-05-30T11:30:00Z",
+  "mode": "standard",
+  "status": "Running",
+  "last_updated_utc": "2026-05-30T11:30:00Z",
+
+  "epics": {
+    "EPIC-02": {
+      "status": "in_progress",
+      "branch": "exec/2026-05-30__release-v4.5/EPIC-02",
+      "pr_number": null,
+      "pr_status": "none",
+      "qa_signed_off": false,
+      "qa_evidence_log": "claude/cycles/2026-05-30__release-v4.5/qa_evidence_EPIC-02.md",
+      "test_scenarios": [],
+      "stories": {
+        "ST-05": {
+          "title": "Standardize 5 agent file role headers",
+          "classification": "autonomous",
+          "status": "in_progress",
+          "assigned_to": "engine",
+          "github_issue": 569,
+          "branch": "exec/2026-05-30__release-v4.5/EPIC-02",
+          "commit_sha": null,
+          "delegation_record_id": null,
+          "blocked_since_utc": null,
+          "unblock_criteria": null,
+          "completed_utc": null,
+          "acceptance_verified": false,
+          "spec_references": ["claude/cycles/2026-05-30__release-v4.5/stage4_backlog_slice.md"],
+          "deviations_filed": false,
+          "last_completed_substep": null,
+          "sign_off_record": null,
+          "notes": ""
+        }
+      }
+    },
+    "EPIC-01": {
+      "status": "not_started",
+      "branch": "exec/2026-05-30__release-v4.5/EPIC-01",
+      "pr_number": null,
+      "pr_status": "none",
+      "qa_signed_off": false,
+      "qa_evidence_log": "claude/cycles/2026-05-30__release-v4.5/qa_evidence_EPIC-01.md",
+      "test_scenarios": [],
+      "stories": {
+        "ST-01": {
+          "title": "execution_prompt.md: split DEL terminal-status write into sign-off and push steps",
+          "classification": "autonomous",
+          "status": "not_started",
+          "assigned_to": "engine",
+          "github_issue": 565,
+          "branch": "exec/2026-05-30__release-v4.5/EPIC-01",
+          "commit_sha": null,
+          "delegation_record_id": null,
+          "blocked_since_utc": null,
+          "unblock_criteria": null,
+          "completed_utc": null,
+          "acceptance_verified": false,
+          "spec_references": ["claude/cycles/2026-05-30__release-v4.5/stage4_backlog_slice.md"],
+          "deviations_filed": false,
+          "last_completed_substep": null,
+          "sign_off_record": null,
+          "notes": ""
+        },
+        "ST-02": {
+          "title": "execution_prompt.md STEP 3.2.B: explicit pr_status sync after PR open",
+          "classification": "autonomous",
+          "status": "not_started",
+          "assigned_to": "engine",
+          "github_issue": 566,
+          "branch": "exec/2026-05-30__release-v4.5/EPIC-01",
+          "commit_sha": null,
+          "delegation_record_id": null,
+          "blocked_since_utc": null,
+          "unblock_criteria": null,
+          "completed_utc": null,
+          "acceptance_verified": false,
+          "spec_references": ["claude/cycles/2026-05-30__release-v4.5/stage4_backlog_slice.md"],
+          "deviations_filed": false,
+          "last_completed_substep": null,
+          "sign_off_record": null,
+          "notes": ""
+        },
+        "ST-03": {
+          "title": "execution_prompt.md: verification-class sub-criterion for pre-planning sprints",
+          "classification": "autonomous",
+          "status": "not_started",
+          "assigned_to": "engine",
+          "github_issue": 567,
+          "branch": "exec/2026-05-30__release-v4.5/EPIC-01",
+          "commit_sha": null,
+          "delegation_record_id": null,
+          "blocked_since_utc": null,
+          "unblock_criteria": null,
+          "completed_utc": null,
+          "acceptance_verified": false,
+          "spec_references": ["claude/cycles/2026-05-30__release-v4.5/stage4_backlog_slice.md"],
+          "deviations_filed": false,
+          "last_completed_substep": null,
+          "sign_off_record": null,
+          "notes": ""
+        },
+        "ST-04": {
+          "title": "execution_prompt.md: spec_references policy for documentation-creation stories",
+          "classification": "autonomous",
+          "status": "not_started",
+          "assigned_to": "engine",
+          "github_issue": 568,
+          "branch": "exec/2026-05-30__release-v4.5/EPIC-01",
+          "commit_sha": null,
+          "delegation_record_id": null,
+          "blocked_since_utc": null,
+          "unblock_criteria": null,
+          "completed_utc": null,
+          "acceptance_verified": false,
+          "spec_references": ["claude/cycles/2026-05-30__release-v4.5/stage4_backlog_slice.md"],
+          "deviations_filed": false,
+          "last_completed_substep": null,
+          "sign_off_record": null,
+          "notes": ""
+        }
+      }
+    }
+  },
+
+  "blocked_items": [],
+  "delegated_items": [],
+  "completed_items": [],
+  "open_escalations": [],
+
+  "merge_gate": {
+    "epics_merged": [],
+    "epics_pending": ["EPIC-02", "EPIC-01"],
+    "all_merged": false
+  },
+
+  "sealed": false,
+  "sealed_utc": null
+}

--- a/claude/cycles/2026-05-30__release-v4.5/execution_state.json
+++ b/claude/cycles/2026-05-30__release-v4.5/execution_state.json
@@ -11,8 +11,8 @@
     "EPIC-02": {
       "status": "done",
       "branch": "exec/2026-05-30__release-v4.5/EPIC-02",
-      "pr_number": null,
-      "pr_status": "none",
+      "pr_number": 573,
+      "pr_status": "open",
       "qa_signed_off": true,
       "qa_evidence_log": "claude/cycles/2026-05-30__release-v4.5/qa_evidence_EPIC-02.md",
       "test_scenarios": [],

--- a/claude/cycles/2026-05-30__release-v4.5/execution_state.json
+++ b/claude/cycles/2026-05-30__release-v4.5/execution_state.json
@@ -9,32 +9,38 @@
 
   "epics": {
     "EPIC-02": {
-      "status": "in_progress",
+      "status": "done",
       "branch": "exec/2026-05-30__release-v4.5/EPIC-02",
       "pr_number": null,
       "pr_status": "none",
-      "qa_signed_off": false,
+      "qa_signed_off": true,
       "qa_evidence_log": "claude/cycles/2026-05-30__release-v4.5/qa_evidence_EPIC-02.md",
       "test_scenarios": [],
       "stories": {
         "ST-05": {
           "title": "Standardize 5 agent file role headers",
           "classification": "autonomous",
-          "status": "in_progress",
+          "status": "done",
           "assigned_to": "engine",
           "github_issue": 569,
           "branch": "exec/2026-05-30__release-v4.5/EPIC-02",
-          "commit_sha": null,
+          "commit_sha": "1b272cfec7524ba2d315007fadbcc9e4bb0baa83",
           "delegation_record_id": null,
           "blocked_since_utc": null,
           "unblock_criteria": null,
-          "completed_utc": null,
-          "acceptance_verified": false,
+          "completed_utc": "2026-05-30T11:35:00Z",
+          "acceptance_verified": true,
           "spec_references": ["claude/cycles/2026-05-30__release-v4.5/stage4_backlog_slice.md"],
-          "deviations_filed": false,
+          "deviations_filed": true,
           "last_completed_substep": null,
-          "sign_off_record": null,
-          "notes": ""
+          "sign_off_record": {
+            "required_by": "Head of Specs Team",
+            "method": "agent_mediated",
+            "status": "cleared",
+            "findings_applied": ["No findings to apply — all 5 AC items passed; pre-existing stray backtick in metrics_definitions_analytics_owner.md noted as out-of-scope for ST-05"],
+            "cleared_utc": "2026-05-30T11:35:00Z"
+          },
+          "notes": "No spec deviation. All 5 agent files updated to **Role:** format; no content altered beyond role header line in each file."
         }
       }
     },
@@ -129,7 +135,7 @@
 
   "blocked_items": [],
   "delegated_items": [],
-  "completed_items": [],
+  "completed_items": ["ST-05"],
   "open_escalations": [],
 
   "merge_gate": {

--- a/claude/cycles/2026-05-30__release-v4.5/qa_evidence_EPIC-02.md
+++ b/claude/cycles/2026-05-30__release-v4.5/qa_evidence_EPIC-02.md
@@ -1,0 +1,34 @@
+Owner: Director of Quality
+Class: Planning Document (Class 4)
+Status: Active
+Last Updated: 2026-05-30
+
+---
+
+# QA Evidence — EPIC-02: Agent Header Standardization
+
+**EPIC:** EPIC-02 — Agent Header Standardization (S2-02)
+**Cycle:** 2026-05-30__release-v4.5
+**Sprint goal:** Deliver all four v4.4 deferred execution_prompt.md governance patches and standardize agent role headers, resolving outstanding audit debt and hardening the governance infrastructure before SI-02 sprint planning begins.
+**Test scenarios used:** Derived from spec + AC (document inspection — no automated test scenarios applicable)
+
+| ST Item | Spec Reference | What was built | Acceptance criteria | Result | Deviations |
+|---------|----------------|----------------|---------------------|--------|------------|
+| ST-05 | stage4_backlog_slice.md#ST-05 | Replaced non-compliant role header format (## Role: / **Owner:**) with `**Role:**` format in 5 agent files; all other content preserved unchanged | AC-01–06: 5 files updated to **Role:** format; all content intact; AC-07: sign-off recorded | Pass | None |
+
+**QA test coverage:**
+- Scenarios run: manual acceptance review (document inspection of 5 agent files; Head of Specs Team agent-mediated sign-off)
+- Regression areas checked: claude/agents/ role scanning; shared/preflight_common.md §2 role-line compliance
+- Known deviations filed: None
+
+---
+
+**Autonomous class eligibility check (BLG-GOV-19):**
+- [x] Criterion 1: All stories in this EPIC have `delegation_class: autonomous` — ✓
+- [x] Criterion 2: All AC verifiable by code review alone — no observable UI behaviour, no staging run required — ✓
+- [x] Criterion 3: No frontend-visible change — no React page or UI component created or modified — ✓
+- [x] Criterion 4: Engine signer field populated as "Sprint Execution Engine (autonomous class)" — ✓
+
+- Signed off by: Sprint Execution Engine (autonomous class)
+- Date: 2026-05-30
+- Comments: Autonomous class sign-off — all four qualifying criteria met (all stories autonomous, all AC code-review-verifiable, no frontend changes, engine signer populated). Head of Specs Team agent-mediated sign-off cleared for ST-05 (all 6 AC items passed; no findings to apply). Pre-existing stray backtick in metrics_definitions_analytics_owner.md noted as out-of-scope; no action required for this EPIC.


### PR DESCRIPTION
## Sprint goal
Deliver all four v4.4 deferred execution_prompt.md governance patches and standardize agent role headers, resolving outstanding audit debt and hardening the governance infrastructure before SI-02 sprint planning begins.

## Stories in this PR

| Story | Title | Status |
|-------|-------|--------|
| ST-05 | Standardize 5 agent file role headers | ✅ Done |

## Acceptance criteria summary
- AC-01–05: 5 agent files updated to `**Role:**` format (api_contracts_documentation_owner, backend_engineering_patterns_owner, data_model_domain_schema_owner, frontend_specs_ux_documentation_owner, metrics_definitions_analytics_owner)
- AC-06: All other content preserved unchanged
- AC-07: Head of Specs Team sign-off recorded (agent-mediated, cleared)

## QA sign-off
Autonomous class sign-off applied (BLG-GOV-19 — all 4 criteria met: all autonomous, all code-review-verifiable, no frontend changes, engine signer populated).
See: `claude/cycles/2026-05-30__release-v4.5/qa_evidence_EPIC-02.md`

## Execution state
`claude/cycles/2026-05-30__release-v4.5/execution_state.json`