### PR TITLE
[GOVERNANCE] Fix missing positions lifecycle migration + close test gap

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1119,6 +1119,27 @@ def update_position_lifecycle_state(
         return dict(row) if row else None
 
 
+def ensure_lifecycle_columns():
+    """Add position_state, state_entered_at, state_history columns to positions (idempotent).
+
+    v2.6 migration — DS-05. All nullable except state_history which defaults to '[]'.
+    Reversible: DROP COLUMN IF EXISTS position_state, state_entered_at, state_history.
+    Spec: docs/specs/data_model.md §Migration v2.6
+    """
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "ALTER TABLE positions ADD COLUMN IF NOT EXISTS position_state VARCHAR(20)"
+            )
+            cur.execute(
+                "ALTER TABLE positions ADD COLUMN IF NOT EXISTS state_entered_at TIMESTAMP WITHOUT TIME ZONE"
+            )
+            cur.execute(
+                "ALTER TABLE positions ADD COLUMN IF NOT EXISTS state_history JSONB NOT NULL DEFAULT '[]'::JSONB"
+            )
+        conn.commit()
+
+
 def ensure_plan_vs_reality_columns():
     """Add plan_vs_reality JSONB to trade_history and planned_stop_price to trade_plans (idempotent).
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -227,6 +227,12 @@ def on_startup():
     except Exception as _e:
         _log.error("ensure_screener_results_table FAILED at startup: %s", _e)
     try:
+        from database import ensure_lifecycle_columns
+        ensure_lifecycle_columns()
+        _log.info("ensure_lifecycle_columns: OK")
+    except Exception as _e:
+        _log.error("ensure_lifecycle_columns FAILED at startup: %s", _e)
+    try:
         from database import ensure_plan_vs_reality_columns
         ensure_plan_vs_reality_columns()
         _log.info("ensure_plan_vs_reality_columns: OK")

--- a/backend/routers/test.py
+++ b/backend/routers/test.py
@@ -139,7 +139,7 @@ async def test_all_endpoints(request: Request):
         {"name": "GET /positions/00000000-0000-0000-0000-000000000000", "method": "GET", "url": f"{base_url}/positions/00000000-0000-0000-0000-000000000000", "critical": False},
         {"name": "POST /positions/00000000-0000-0000-0000-000000000000/refresh-state", "method": "POST", "url": f"{base_url}/positions/00000000-0000-0000-0000-000000000000/refresh-state", "critical": False},
         # Position Lifecycle Decision Support (v3.3 / EPIC-02)
-        {"name": "GET /positions/grace-period-alerts", "method": "GET", "url": f"{base_url}/positions/grace-period-alerts", "critical": False},
+        {"name": "GET /positions/grace-period-alerts", "method": "GET", "url": f"{base_url}/positions/grace-period-alerts", "critical": True},
         {"name": "GET /positions/{id}/stop-trail", "method": "GET", "url": f"{base_url}/positions/00000000-0000-0000-0000-000000000000/stop-trail", "critical": False},
 
         # Portfolio Risk (v3.4 / EPIC-02)

--- a/claude/backlog/backlog.md
+++ b/claude/backlog/backlog.md
@@ -3,7 +3,7 @@
 **Owner:** Product Owner
 **Status:** Active
 **Class:** Planning Document (Class 4)
-**Last Updated:** 2026-06-01 (rebalance 2026-06-01__scheduled — DL-036; 11 new items: BLG-GOV-69–74, BLG-OPS-46–48, BLG-QA-39, BLG-SPEC-43)
+**Last Updated:** 2026-06-01 (session — 2 new items added: BLG-QA-40, BLG-QA-41)
 **Last rebalance:** 2026-06-01 (cycle 2026-06-01__scheduled — DL-036; IW-20260601-01; 11 new items; 50 ideas classified)
 
 > ⚠️ Standing Notice
@@ -1093,6 +1093,53 @@ v4.7 shipped compliance_summary field in GET /reports/monthly-pnl (ST-03, EPIC-0
 - Coverage matrix includes compliance_summary field with regression test reference
 - GET /reports/monthly-pnl v0.6 confirmed in API contract documentation
 - Any contract gaps filed as BLG-SPEC items
+
+---
+
+### BLG-QA-40 — Wire Phase B CI with real Postgres service to catch missing-column errors
+**Priority:** P2 (Medium)
+**Type:** QA / Test Automation
+**Owner:** QA Lead; Head of Engineering
+**Source:** Bug: position_state column missing from positions table, not caught by CI — 2026-06-01
+**Effort:** M (~1–2 days)
+**Provisional-Target:** v4.9
+
+**Problem**
+The Phase A CI suite (ci-tests.yml) runs against a stub DATABASE_URL with all DB calls mocked, making missing schema columns completely invisible to CI. When `position_state`, `state_entered_at`, and `state_history` were never added to the `positions` table via a startup migration, every endpoint that queried those columns returned a 500 in production — yet all CI jobs were green. The ci-tests.yml workflow comment explicitly notes Phase B ("requires DATABASE_URL secret") was deferred; until it is wired, no automated job will catch a column referenced in SQL that doesn't exist in the DB.
+
+**Scope**
+- Spin up a Postgres service container in ci-tests.yml (GitHub Actions `services:` block)
+- Wire the `DATABASE_URL` secret for the Phase B job step
+- Enable the Phase B test run (currently commented out in the workflow)
+- Verify all existing integration tests pass against the real service container
+
+**Acceptance Criteria**
+- A PR that introduces a SQL query referencing a non-existent column causes the CI Phase B job to fail
+- Phase A (stub/mock tests) continues to run without a real DB
+- No test collection errors in Phase B
+
+---
+
+### BLG-QA-41 — Schema smoke test: assert lifecycle columns exist on positions table
+**Priority:** P3 (Low)
+**Type:** QA / Test Automation
+**Owner:** QA Lead
+**Source:** Bug: position_state column missing from positions table, not caught by CI — 2026-06-01
+**Effort:** S (~0.5 day)
+**Provisional-Target:** v4.9
+**Depends on:** BLG-QA-40 (Phase B CI with real Postgres required)
+
+**Problem**
+There is no test that verifies the `positions` table contains the lifecycle columns (`position_state`, `state_entered_at`, `state_history`) that `ensure_lifecycle_columns()` is supposed to create. Without this, a missing `ensure_*` call at startup — or a call that silently errors — leaves a schema gap that is only discovered when a user hits the broken endpoint. A schema introspection test would close this class of bug permanently.
+
+**Scope**
+- Add a test (in `tests/test_position_lifecycle.py` or a new `tests/test_schema.py`) that calls `ensure_lifecycle_columns()` and then queries `information_schema.columns` to assert all three columns are present on the `positions` table
+- Test must run under Phase B CI (real Postgres) and be excluded from Phase A
+
+**Acceptance Criteria**
+- Test fails if any of `position_state`, `state_entered_at`, `state_history` is absent from the `positions` table
+- Test is skipped/excluded when `DATABASE_URL` points to the stub (Phase A)
+- Test passes in the Phase B CI environment
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `ensure_lifecycle_columns()` in `database.py` to create `position_state`, `state_entered_at`, and `state_history` columns on the `positions` table at startup (idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`)
- Wires the call into the startup block in `main.py` — this fixes the `GET /positions/grace-period-alerts` 500 error caused by these columns never being added to the DB despite being referenced in SQL
- Marks `GET /positions/grace-period-alerts` as `critical: True` in `backend/routers/test.py` so staging smoke runs surface failures rather than silently passing
- Files BLG-QA-40 and BLG-QA-41 to track Phase B CI (real Postgres) and schema smoke test work

## Root cause
The data model spec (v2.6) defined the migration SQL for these three columns and the service code was written assuming they exist, but no `ensure_*` startup migration function was ever created to actually add them. The gap was invisible to CI because all tests mock the database.

## Test plan
- [ ] Restart the backend — confirm `ensure_lifecycle_columns: OK` appears in startup logs
- [ ] Hit `GET /positions/grace-period-alerts` — confirm 200 response (empty array if no GRACE positions)
- [ ] Confirm `GET /positions/grace-period-alerts` appears as `critical: True` in the `/test` endpoint results

🤖 Generated with [Claude Code](https://claude.com/claude-code)