### PR TITLE
[GOVERNANCE] Fix grace-period-alerts stop_level column reference

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1030,7 +1030,7 @@ def get_grace_period_alerts_endpoint():
                     SELECT p.id, p.ticker, p.market, p.position_state, p.state_entered_at,
                            p.entry_date, p.entry_price, p.atr, p.initial_stop,
                            tp.id AS trade_plan_id,
-                           tp.setup_thesis, tp.entry_rationale, tp.stop_level, tp.r_target
+                           tp.setup_thesis, tp.entry_rationale, tp.planned_stop_price AS stop_level, tp.r_target
                     FROM positions p
                     LEFT JOIN trade_plans tp ON tp.position_id = p.id
                     WHERE p.portfolio_id = %s AND p.status = 'open'


### PR DESCRIPTION
## Summary
- Fixes a second missing-column error on `GET /positions/grace-period-alerts`: the SQL query referenced `tp.stop_level` but the column on `trade_plans` is `tp.planned_stop_price` (added by `ensure_plan_vs_reality_columns`)
- Changed to `tp.planned_stop_price AS stop_level` so the alias matches the API contract response shape while pointing at the column that actually exists

## Context
Discovered immediately after #613 was merged. #613 fixed the `position_state` missing columns; this fixes the next error encountered on the same endpoint.

## Test plan
- [ ] Hit `GET /positions/grace-period-alerts` — confirm 200 response with no column errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)