### PR TITLE
[GOVERNANCE] Fix missing trade_history.fill_price migration

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1213,6 +1213,21 @@ def ensure_signals_watchlisted_status():
         conn.commit()
 
 
+def ensure_trade_history_fill_price_column():
+    """Add fill_price to trade_history (idempotent).
+
+    v1.9→v2.0 migration — slippage tracking. Copied from positions.user_fill_price at exit.
+    Nullable; existing records default null.
+    Spec: docs/specs/data_model.md §Migration v2.0
+    """
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "ALTER TABLE trade_history ADD COLUMN IF NOT EXISTS fill_price NUMERIC(10, 4)"
+            )
+        conn.commit()
+
+
 def ensure_planned_entry_price_column():
     """Add planned_entry_price to trade_history (idempotent).
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -275,6 +275,18 @@ def on_startup():
     except Exception as _e:
         _log.error("ensure_gemini_audit_log_table FAILED at startup: %s", _e)
     try:
+        from database import ensure_trade_history_fill_price_column
+        ensure_trade_history_fill_price_column()
+        _log.info("ensure_trade_history_fill_price_column: OK")
+    except Exception as _e:
+        _log.error("ensure_trade_history_fill_price_column FAILED at startup: %s", _e)
+    try:
+        from database import ensure_planned_entry_price_column
+        ensure_planned_entry_price_column()
+        _log.info("ensure_planned_entry_price_column: OK")
+    except Exception as _e:
+        _log.error("ensure_planned_entry_price_column FAILED at startup: %s", _e)
+    try:
         from utils.feature_flags import log_flag_states
         log_flag_states()
     except Exception as _e:


### PR DESCRIPTION
## Summary
- Adds `ensure_trade_history_fill_price_column()` in `database.py` to create `fill_price` on `trade_history` (v1.9→v2.0 migration that was never wired up), fixing a 500 on every trade exit
- Wires both `ensure_trade_history_fill_price_column()` and `ensure_planned_entry_price_column()` into the startup block — `ensure_planned_entry_price_column` already existed in `database.py` but was never called at startup

## Root cause
`create_trade_history()` inserts into `fill_price` and `planned_entry_price` on `trade_history`, but neither column existed on fresh deployments: `fill_price` had no `ensure_*` function at all, and `ensure_planned_entry_price_column` was defined but never called. The exit flow gets all the way through P&L calculation before hitting the INSERT and crashing.

## Test plan
- [ ] Restart the backend — confirm both `ensure_trade_history_fill_price_column: OK` and `ensure_planned_entry_price_column: OK` in startup logs
- [ ] Exit a trade — confirm 200 response and trade appears in history

🤖 Generated with [Claude Code](https://claude.com/claude-code)