### PR TITLE
[GOVERNANCE] Fix screener 401 cooldown loop and results 404 on poll

### DIFF
--- a/backend/routers/screener.py
+++ b/backend/routers/screener.py
@@ -5,6 +5,7 @@ Contract: docs/specs/api_contracts/screener_api_contract.md
 import logging
 import uuid
 from fastapi import APIRouter, HTTPException, BackgroundTasks
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional, List
 from services.screener_batch_service import run_screener, get_screener_results, is_run_in_progress
@@ -38,6 +39,14 @@ def screener_results(
         data = get_screener_results(market=market, run_id=run_id, limit=limit, offset=offset)
         return {"ok": True, "data": data}
     except ValueError:
+        # If a run is currently in progress and the caller supplied a run_id,
+        # return 202 so the frontend keeps polling instead of treating it as a
+        # hard failure.
+        if run_id and is_run_in_progress():
+            return JSONResponse(
+                status_code=202,
+                content={"ok": True, "data": {"status": "running", "run_id": run_id}},
+            )
         raise HTTPException(status_code=404, detail="NO_RESULTS")
 
 

--- a/backend/services/screener_data_service.py
+++ b/backend/services/screener_data_service.py
@@ -38,6 +38,8 @@ _yahoo_session: Optional[requests.Session] = None
 _yahoo_crumb: Optional[str] = None
 _yahoo_cooldown_until: float = 0.0  # monotonic; 0 = no cooldown active
 _YAHOO_COOLDOWN_SECS = 120  # back off 2 minutes after a 429 on the crumb endpoint
+_YAHOO_401_COOLDOWN_SECS = 60   # back off 1 minute after 3 consecutive 401s
+_crumb_consecutive_401s: int = 0
 
 OHLCVRecord = Dict[str, object]
 
@@ -48,7 +50,7 @@ OHLCVRecord = Dict[str, object]
 
 def _refresh_yahoo_crumb() -> Optional[str]:
     """Establish a new Yahoo Finance session and fetch a fresh crumb token."""
-    global _yahoo_session, _yahoo_crumb, _yahoo_cooldown_until
+    global _yahoo_session, _yahoo_crumb, _yahoo_cooldown_until, _crumb_consecutive_401s
     with _crumb_lock:
         # Skip the network call entirely while in cooldown
         if _time.monotonic() < _yahoo_cooldown_until:
@@ -61,14 +63,28 @@ def _refresh_yahoo_crumb() -> Optional[str]:
                 _yahoo_session = sess
                 _yahoo_crumb = resp.text.strip()
                 _yahoo_cooldown_until = 0.0
+                _crumb_consecutive_401s = 0
                 logger.info("Yahoo Finance crumb refreshed successfully")
                 return _yahoo_crumb
             if resp.status_code == 429:
+                _crumb_consecutive_401s = 0
                 _yahoo_cooldown_until = _time.monotonic() + _YAHOO_COOLDOWN_SECS
                 logger.warning(
                     "Yahoo Finance crumb fetch returned HTTP 429 — entering %ds cooldown",
                     _YAHOO_COOLDOWN_SECS,
                 )
+            elif resp.status_code == 401:
+                _crumb_consecutive_401s += 1
+                logger.warning(
+                    "Yahoo Finance crumb fetch returned HTTP 401 (consecutive: %d)",
+                    _crumb_consecutive_401s,
+                )
+                if _crumb_consecutive_401s >= 3:
+                    _yahoo_cooldown_until = _time.monotonic() + _YAHOO_401_COOLDOWN_SECS
+                    logger.warning(
+                        "Yahoo Finance crumb returned 401 %d times — entering %ds cooldown",
+                        _crumb_consecutive_401s, _YAHOO_401_COOLDOWN_SECS,
+                    )
             else:
                 logger.warning("Yahoo Finance crumb fetch returned HTTP %d", resp.status_code)
         except requests.RequestException as exc:

--- a/tests/test_screener_data_service.py
+++ b/tests/test_screener_data_service.py
@@ -13,6 +13,29 @@ from tests.mock_harness.api_mock_harness import ScreenerMockHarness, AlpacaMockH
 
 
 # ---------------------------------------------------------------------------
+# Reset Yahoo Finance module state before every test so cooldown and
+# consecutive-401 counters from one test cannot affect subsequent tests.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_yahoo_state():
+    import services.screener_data_service as svc
+    svc._yahoo_crumb = None
+    svc._yahoo_session = None
+    svc._yahoo_cooldown_until = 0.0
+    svc._crumb_consecutive_401s = 0
+    if hasattr(svc._yahoo_fetch_ohlcv, "_consecutive_401"):
+        del svc._yahoo_fetch_ohlcv._consecutive_401
+    yield
+    svc._yahoo_crumb = None
+    svc._yahoo_session = None
+    svc._yahoo_cooldown_until = 0.0
+    svc._crumb_consecutive_401s = 0
+    if hasattr(svc._yahoo_fetch_ohlcv, "_consecutive_401"):
+        del svc._yahoo_fetch_ohlcv._consecutive_401
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Two bugs from the async screener fix (81089bc4):

**Bug 1 — Yahoo Finance 401 loop (~90 crumb requests, all failing)**
`_refresh_yahoo_crumb` only triggered a cooldown on HTTP 429, not 401. When Yahoo Finance returns 401 (bad session/crumb), every ticker in the batch attempted a fresh crumb call — ~90 attempts over 3 minutes before eventually hitting a 429 and entering the cooldown. Result: every OHLCV fetch fails with "no data from any source".

Fix: after 3 consecutive 401s on the crumb endpoint, enter a 60s cooldown so all remaining tickers fast-fail without further network calls.

**Bug 2 — 404 on `GET /screener/results?run_id=...` while run is in progress**
The `run_id` is generated and returned in the 202 response before the background run completes. When the frontend polls immediately, the `run_id` doesn't exist in `screener_runs` yet → `get_screener_results` raises `ValueError` → endpoint returns 404 → frontend stops polling.

Fix: when a `run_id` is provided and a run is currently in progress, return 202 with `{status: "running", run_id: ...}` so the frontend continues polling.

## Test plan
- [ ] Trigger a screener run — confirm `POST /screener/run` returns 202
- [ ] Poll `GET /screener/results?run_id=<id>` immediately — confirm 202 with `status: running` (not 404)
- [ ] Once run completes — confirm `GET /screener/results?run_id=<id>` returns 200 with results
- [ ] If Yahoo Finance returns 401 repeatedly — confirm logs show cooldown entry after 3 consecutive failures rather than continuing to hammer the endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)