### PR TITLE
[GOVERNANCE] Revert Twelve Data ticker format to symbol + exchange=LSE

### DIFF
--- a/backend/services/screener_data_service.py
+++ b/backend/services/screener_data_service.py
@@ -262,8 +262,13 @@ def _twelve_data_fetch_ohlcv(ticker: str, days: int) -> Optional[List[OHLCVRecor
         logger.warning("TWELVE_DATA_API_KEY not configured — skipping Twelve Data for %s", ticker)
         return None
 
-    # Pass ticker as-is — Twelve Data accepts Yahoo Finance .L suffix natively
-    symbol = ticker.upper()
+    # Twelve Data uses symbol + exchange=LSE, not the .L suffix
+    if ticker.upper().endswith(".L"):
+        symbol = ticker[:-2].upper()
+        exchange = "LSE"
+    else:
+        symbol = ticker.upper()
+        exchange = None
 
     _twelve_data_rate_wait()
     t0 = _time.monotonic()
@@ -273,9 +278,9 @@ def _twelve_data_fetch_ohlcv(ticker: str, days: int) -> Optional[List[OHLCVRecor
             "interval": "1day",
             "outputsize": max(days, 30),
             "apikey": _TWELVE_DATA_API_KEY,
-            "format": "JSON",
-            "order": "ASC",
         }
+        if exchange:
+            params["exchange"] = exchange
 
         resp = requests.get(_TWELVE_DATA_URL, params=params, timeout=15)
         latency = (_time.monotonic() - t0) * 1000


### PR DESCRIPTION
## Summary
The previous commit that passed `AAF.L` directly to Twelve Data was wrong — it caused 404 for **all** tickers including ones that were previously reaching the API successfully (they got 429 rate limit, not 404). Twelve Data does not accept the Yahoo Finance `.L` suffix.

Reverts to `symbol=AAF&exchange=LSE` format. Tickers that return 404 with this format are genuinely not in Twelve Data's database (some smaller FTSE stocks). Tickers that are in the database will now work correctly with the rate limiter from the previous PR.

## Test plan
- [ ] Run screener — confirm major UK tickers (AZN, BP, HSBA etc.) show `OHLCV OK via Twelve Data`
- [ ] Confirm 404s only for genuinely unlisted tickers, not for all tickers
- [ ] Confirm no 429 rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)