### PR TITLE
[GOVERNANCE] Run UK screener tickers sequentially via Yahoo Finance only

### DIFF
--- a/backend/services/screener_batch_service.py
+++ b/backend/services/screener_batch_service.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import threading
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -269,8 +270,33 @@ def run_screener(ticker_universe: Optional[List[str]] = None,
             )
             return record, True
 
+        # Split UK and US so we can use different fetch strategies.
+        # UK: sequential with inter-request delay — Yahoo Finance rate-limits hard
+        #     under concurrent load; 0.3s spacing keeps it under the threshold.
+        # US: concurrent thread pool — Alpaca handles concurrency fine.
+        def _is_uk(row: Dict) -> bool:
+            m = row.get("market") or ("UK" if row["ticker"].upper().endswith(".L") else "US")
+            return m == "UK"
+
+        uk_rows = [r for r in ticker_rows if _is_uk(r)]
+        us_rows = [r for r in ticker_rows if not _is_uk(r)]
+
+        for row in uk_rows:
+            time.sleep(0.3)
+            try:
+                record, had_ohlcv = _process_row_tracked(row)
+                if not had_ohlcv:
+                    ohlcv_failures += 1
+                else:
+                    tickers_evaluated += 1
+                    if record is not None:
+                        results.append(record)
+            except Exception as exc:
+                logger.warning("Screener batch error for %s: %s", row.get("ticker"), exc)
+                ohlcv_failures += 1
+
         with ThreadPoolExecutor(max_workers=YF_MAX_CONCURRENT) as executor:
-            futures = {executor.submit(_process_row_tracked, row): row for row in ticker_rows}
+            futures = {executor.submit(_process_row_tracked, row): row for row in us_rows}
             for future in as_completed(futures):
                 row = futures[future]
                 try:

--- a/backend/services/screener_data_service.py
+++ b/backend/services/screener_data_service.py
@@ -460,15 +460,9 @@ def fetch_ohlcv(ticker: str, market: str, days: int = 30) -> Optional[List[OHLCV
         logger.warning("OHLCV FAILED for %s (market=%s) — no data from any source", ticker, market)
         return None
 
-    # UK tickers: Twelve Data primary → Stooq → Yahoo Finance
-    result = _twelve_data_fetch_ohlcv(ticker, days)
-    if result:
-        return result
-    logger.info("Twelve Data unavailable for %s — falling back to Stooq", ticker)
-    result = _stooq_fetch_ohlcv(ticker, days)
-    if result:
-        return result
-    logger.info("Stooq unavailable for %s — falling back to Yahoo Finance", ticker)
+    # UK tickers: Yahoo Finance only.
+    # Twelve Data requires a paid plan for LSE symbols.
+    # Stooq consistently times out from Render's IP range.
     result = _yahoo_fetch_ohlcv(ticker, days)
     if result:
         return result


### PR DESCRIPTION
## Summary

- Removes Twelve Data and Stooq from the UK OHLCV fetch path — Twelve Data requires a paid plan for LSE symbols (all return 404 on free tier); Stooq consistently ConnectTimeouts from Render's IP range
- UK tickers now run sequentially with 0.3s inter-request spacing, matching the pattern used by the signal service — eliminates the burst of 5 concurrent Yahoo requests that was triggering sustained 429s
- US tickers continue to use the concurrent ThreadPoolExecutor path via Alpaca (unchanged)

## Test plan

- [ ] Deploy to Render and run a UK screener
- [ ] Confirm `OHLCV OK via Yahoo Finance for X.L` log lines appear
- [ ] Confirm no sustained `429` bursts in logs
- [ ] Note: UK run will take ~30s longer than before (100 tickers × 0.3s) — expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)