### PR TITLE
[GOVERNANCE] Trade plan improvements — regime display, pre-entry persistence, AI prompt accuracy

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -968,9 +968,10 @@ def create_trade_plan(portfolio_id: str, data: dict) -> dict:
                    (portfolio_id, position_id, ticker, market, setup_type, setup_thesis, entry_rationale,
                     regime_context_at_entry, r_target, early_exit_conditions, confirmation_criteria,
                     checklist_completed, checklist_items, status, pre_entry_override_acknowledged,
+                    planned_quantity, planned_entry_price, planned_stop_price,
                     signal_id, risk_percent_used, portfolio_value_at_entry,
                     pre_entry_validation_snapshot, effective_settings_snapshot)
-                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s,%s,%s,%s,%s,%s::jsonb,%s::jsonb)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s::jsonb)
                    RETURNING *""",
                 (
                     portfolio_id,
@@ -988,6 +989,9 @@ def create_trade_plan(portfolio_id: str, data: dict) -> dict:
                     _json(data.get("checklist_items", [])),
                     data.get("status", "draft"),
                     data.get("pre_entry_override_acknowledged"),
+                    data.get("planned_quantity"),
+                    data.get("planned_entry_price"),
+                    data.get("planned_stop_price"),
                     data.get("signal_id"),
                     data.get("risk_percent_used"),
                     data.get("portfolio_value_at_entry"),
@@ -1036,6 +1040,7 @@ def update_trade_plan(trade_plan_id: str, portfolio_id: str, data: dict) -> dict
         "r_target", "early_exit_conditions", "confirmation_criteria",
         "checklist_completed", "checklist_items", "status", "abandonment_reason",
         "pre_entry_override_acknowledged",
+        "planned_quantity", "planned_entry_price", "planned_stop_price",
     }
     fields = {k: v for k, v in data.items() if k in allowed}
     if not fields:
@@ -1237,6 +1242,23 @@ def ensure_planned_entry_price_column():
         with conn.cursor() as cur:
             cur.execute(
                 "ALTER TABLE trade_history ADD COLUMN IF NOT EXISTS planned_entry_price NUMERIC(20, 6)"
+            )
+        conn.commit()
+
+
+def ensure_trade_plan_pre_entry_columns():
+    """Add planned_quantity and planned_entry_price to trade_plans (idempotent).
+
+    Persists pre-entry check inputs so they survive save/reload cycles.
+    planned_stop_price already exists (ensure_plan_vs_reality_columns).
+    """
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "ALTER TABLE trade_plans ADD COLUMN IF NOT EXISTS planned_quantity INTEGER"
+            )
+            cur.execute(
+                "ALTER TABLE trade_plans ADD COLUMN IF NOT EXISTS planned_entry_price NUMERIC(20, 6)"
             )
         conn.commit()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -287,6 +287,12 @@ def on_startup():
     except Exception as _e:
         _log.error("ensure_planned_entry_price_column FAILED at startup: %s", _e)
     try:
+        from database import ensure_trade_plan_pre_entry_columns
+        ensure_trade_plan_pre_entry_columns()
+        _log.info("ensure_trade_plan_pre_entry_columns: OK")
+    except Exception as _e:
+        _log.error("ensure_trade_plan_pre_entry_columns FAILED at startup: %s", _e)
+    try:
         from utils.feature_flags import log_flag_states
         log_flag_states()
     except Exception as _e:

--- a/backend/routers/trade_plans.py
+++ b/backend/routers/trade_plans.py
@@ -53,6 +53,10 @@ class TradePlanCreate(BaseModel):
     checklist_items: list = []
     status: str = "draft"
     pre_entry_override_acknowledged: Optional[bool] = None
+    # Pre-entry check inputs — persisted so they survive save/reload
+    planned_quantity: Optional[int] = None
+    planned_entry_price: Optional[float] = None
+    planned_stop_price: Optional[float] = None
     # SI-02 DS-07 fields (frontend-passed)
     signal_id: Optional[str] = None
     risk_percent_used: Optional[float] = None
@@ -73,6 +77,9 @@ class TradePlanUpdate(BaseModel):
     status: Optional[str] = None
     abandonment_reason: Optional[str] = None
     pre_entry_override_acknowledged: Optional[bool] = None
+    planned_quantity: Optional[int] = None
+    planned_entry_price: Optional[float] = None
+    planned_stop_price: Optional[float] = None
 
 
 def _get_portfolio_id():
@@ -267,6 +274,10 @@ class GeneratePlanRequest(BaseModel):
     market: str = "US"
     setup_type: Optional[str] = None
     signal_data: Optional[dict] = None
+    planned_entry_price: Optional[float] = None
+    planned_stop_price: Optional[float] = None
+    planned_quantity: Optional[int] = None
+    r_target: Optional[float] = None
 
 
 @router.post("/generate-plan")
@@ -284,6 +295,10 @@ def generate_plan(body: GeneratePlanRequest):
             market=body.market,
             setup_type=body.setup_type,
             signal_data=body.signal_data,
+            planned_entry_price=body.planned_entry_price,
+            planned_stop_price=body.planned_stop_price,
+            planned_quantity=body.planned_quantity,
+            r_target=body.r_target,
         )
         return {"status": "ok", "data": result}
     except Exception as e:

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -21,21 +21,35 @@ ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
 MODEL_VERSION = "claude-haiku-4-5"
 PROMPT_VERSION = "v3.0"
 
-_FULL_PLAN_PROMPT = """You are a systematic swing trader. Given the trade context below, fill in all sections of a trade plan.
+_FULL_PLAN_PROMPT = """You are a systematic swing trader documenting a trade plan. Write all sections to accurately reflect the exact trade being made — do not use generic language that doesn't match the actual parameters.
 
 Ticker: {ticker}
 Market: {market}
 Setup type: {setup_type}
 Signal data: {signal_summary}
+Entry price: {entry_price}
+Stop price: {stop_price}
+Stop method: {stop_method}
+Planned shares: {quantity}
+R-target: {r_target}
+Risk per share: {risk_per_share}
+
+Rules:
+- entry_rationale must describe entering at the stated entry price, not a hypothetical breakout or pullback unless that is literally what is happening
+- early_exit_conditions must reference the actual stop price, not a moving average unless they coincide
+- confirmation_criteria should only include criteria that can actually be verified at entry
+- regime_context_at_entry must reflect risk-on/off status consistent with the signal being generated
+- r_target in the JSON must match the stated R-target above exactly
+- Be specific and concise. No generic filler.
 
 Return ONLY a JSON object with exactly these keys (no markdown, no preamble):
 {{
   "regime_context_at_entry": "1 sentence on current market regime — risk-on/off, trend, sector strength.",
-  "setup_thesis": "2-3 sentence thesis explaining why this setup is valid now. Under 100 words.",
-  "entry_rationale": "1-2 sentences on the specific reason to enter — what technical or fundamental condition makes this a candidate.",
-  "confirmation_criteria": "1-2 sentences on what must be true at entry — price action, volume, regime.",
-  "early_exit_conditions": "1-2 sentences on conditions that would invalidate the thesis before the stop is hit.",
-  "r_target": <number between 1.5 and 4.0 based on setup quality, or null if unknown>
+  "setup_thesis": "2-3 sentence thesis explaining why this setup is valid now, referencing the momentum signal. Under 100 words.",
+  "entry_rationale": "1-2 sentences on why entering at {entry_price} now — what condition makes this the entry point.",
+  "confirmation_criteria": "1-2 sentences on verifiable conditions at entry — price action, volume, regime.",
+  "early_exit_conditions": "1-2 sentences referencing the stop at {stop_price} and what invalidates the thesis.",
+  "r_target": {r_target_num}
 }}"""
 
 _THESIS_PROMPT_TEMPLATE = """You are a systematic swing trader. Generate a concise setup thesis (2-3 sentences) for the following trade context.
@@ -125,6 +139,10 @@ def generate_full_plan(
     setup_type: Optional[str] = None,
     signal_data: Optional[dict] = None,
     plan_id: Optional[str] = None,
+    planned_entry_price: Optional[float] = None,
+    planned_stop_price: Optional[float] = None,
+    planned_quantity: Optional[int] = None,
+    r_target: Optional[float] = None,
 ) -> dict:
     """
     Generate all plan fields in one call: setup_thesis, entry_rationale,
@@ -142,15 +160,44 @@ def generate_full_plan(
 
     signal_summary = _build_signal_summary(signal_data)
 
+    # Derive stop method description
+    atr = signal_data.get("atr_value") if signal_data else None
+    if planned_entry_price and planned_stop_price and atr:
+        risk = planned_entry_price - planned_stop_price
+        atr_mult = round(risk / atr, 1) if atr > 0 else None
+        stop_method = f"{atr_mult}×ATR below entry" if atr_mult else "ATR-based"
+    elif planned_entry_price and planned_stop_price:
+        stop_method = "fixed price stop"
+    else:
+        stop_method = "ATR-based per signal"
+
+    risk_per_share = (
+        round(planned_entry_price - planned_stop_price, 2)
+        if planned_entry_price and planned_stop_price
+        else "unknown"
+    )
+
     prompt = _FULL_PLAN_PROMPT.format(
         ticker=ticker.upper(),
         market=market,
         setup_type=setup_type or "Not specified",
         signal_summary=signal_summary,
+        entry_price=f"${planned_entry_price}" if planned_entry_price else "market price",
+        stop_price=f"${planned_stop_price}" if planned_stop_price else "per signal",
+        stop_method=stop_method,
+        quantity=planned_quantity if planned_quantity else "per model sizing",
+        r_target=r_target if r_target else "to be determined",
+        risk_per_share=f"${risk_per_share}" if risk_per_share != "unknown" else "unknown",
+        r_target_num=r_target if r_target else "null",
     )
 
     input_payload = json.dumps(
-        {"ticker": ticker, "market": market, "setup_type": setup_type, "signal_data": signal_data},
+        {
+            "ticker": ticker, "market": market, "setup_type": setup_type,
+            "signal_data": signal_data, "planned_entry_price": planned_entry_price,
+            "planned_stop_price": planned_stop_price, "planned_quantity": planned_quantity,
+            "r_target": r_target,
+        },
         sort_keys=True, default=str,
     )
     input_hash = hashlib.sha256(input_payload.encode()).hexdigest()[:16]

--- a/claude/backlog/backlog.md
+++ b/claude/backlog/backlog.md
@@ -3,7 +3,7 @@
 **Owner:** Product Owner
 **Status:** Active
 **Class:** Planning Document (Class 4)
-**Last Updated:** 2026-06-02 (post-ship closure 2026-06-01__release-v4.8 — 7 items COMPLETE; BLG-GOV-78 added)
+**Last Updated:** 2026-06-02 (session — 2 new items added: BLG-FEAT-43, BLG-BE-25)
 **Last rebalance:** 2026-06-01 (cycle 2026-06-01__scheduled — DL-036; IW-20260601-01; 11 new items; 50 ideas classified)
 
 > ⚠️ Standing Notice
@@ -386,6 +386,33 @@ The Gemini thesis generation feature (shipped v4.0) writes to the setup_thesis f
 - Metric defined in metrics_definitions.md
 - Query approach documented (gemini_audit_log join trade_plans)
 - Reviewed by Financial Reporting & Records Owner and Product Owner
+
+---
+
+### BLG-FEAT-43 — Insufficient-allocation signal: distinct status and inline explanation
+**Priority:** P2 (Medium)
+**Type:** Product Feature / Signal UX
+**Owner:** Head of Backend Engineering; Head of UX & Design
+**Source:** PO direction — 2026-06-02
+**Effort:** S (~0.5 day)
+**Provisional-Target:** v4.9
+
+**Problem**
+When a signal's per-share GBP price exceeds the per-position allocation budget, the backend returns suggested_shares=0 but leaves status as "new" — indistinguishable from an actionable buy signal. SNDK has been rank-1 for weeks at ~£1,259/share against a ~£1,147 allocation, silently returning 0 shares with no explanation. For high-priced stocks this is a structural recurring gap, not an edge case.
+
+**Scope**
+- Backend: set status to "allocation_insufficient" (not "new") when suggested_shares=0 and price_gbp > allocation_gbp
+- Backend: include a human-readable reason field (e.g. "1 share (£1,259) exceeds position allocation (£1,147) — cannot size")
+- Frontend: display the reason inline on the signal card/row when status is "allocation_insufficient"
+- Frontend: visually differentiate allocation_insufficient signals from actionable new signals
+- (Deferred) Override path allowing user to manually record a share count — scope to be defined if and when taken up
+
+**Acceptance Criteria**
+- Signal with price_gbp > allocation_gbp has status "allocation_insufficient", not "new"
+- A reason string is returned from the backend and displayed inline in the signal view
+- Allocation_insufficient signals are visually distinct from new/watchlisted signals
+- Existing signals with status "new" and suggested_shares > 0 are unaffected
+- No change to already_held or watchlisted status logic
 
 ---
 
@@ -897,6 +924,27 @@ The red_flag_events table has no defined data retention policy. As override even
 - Retention policy document produced
 - Archiving cadence defined
 - Gate condition (table 6+ months old) verified before commencing
+
+### BLG-BE-25 — Fix pre-entry regime gate to use shared market status instead of independent yf.download
+**Priority:** P2 (Medium)
+**Type:** Backend Engineering
+**Owner:** Head of Backend Engineering
+**Source:** User-reported — pre-entry regime gate shows risk_off while dashboard shows risk_on — 2026-06-02
+**Effort:** S (~0.5d)
+**Provisional-Target:** v4.9
+
+**Problem**
+`_check_regime()` in `pre_entry_validation.py` calls `check_market_regime()` directly, which triggers a fresh `yf.download("SPY")` / `yf.download("^FTSE")` call independent of the `/market/status` endpoint. On rapid sequential requests, Yahoo Finance can return slightly different data (different row counts, trailing NaN values), causing the rolling 200MA calculation to resolve differently. This produces spurious regime_gate failures that contradict the authoritative dashboard reading, eroding user trust in the pre-entry check.
+
+**Scope**
+- Refactor `_check_regime()` to call `GET /market/status` (or a shared in-process cache) rather than invoking `check_market_regime()` directly
+- Ensure the regime result used in pre-entry validation is always consistent with what `/market/status` returns
+- Add a server-side cache (e.g. 5-minute TTL) to `check_market_regime()` so all callers share one result per window
+
+**Acceptance Criteria**
+- Dashboard regime and pre-entry regime gate always agree when called within the same session
+- No spurious risk_off failures when SPY is clearly above its 200MA per the dashboard
+- `/portfolio/pre-entry-validation` does not make an independent `yf.download` call
 
 ---
 

--- a/src/pages/TradePlan.js
+++ b/src/pages/TradePlan.js
@@ -272,6 +272,9 @@ const EMPTY_FORM = {
   checklist_items: DEFAULT_CHECKLIST_ITEMS.map((i) => ({ ...i })),
   status: "draft",
   pre_entry_override_acknowledged: false,
+  planned_quantity: "",
+  planned_entry_price: "",
+  planned_stop_price: "",
 };
 
 function Field({ label, children }) {
@@ -331,9 +334,6 @@ export default function TradePlan() {
   const [showAbandonModal, setShowAbandonModal] = useState(false);
   const [abandonReason, setAbandonReason] = useState("");
   const [abandonReasonTouched, setAbandonReasonTouched] = useState(false);
-  const [plannedQuantity, setPlannedQuantity] = useState("");
-  const [plannedEntryPrice, setPlannedEntryPrice] = useState("");
-  const [plannedStopPrice, setPlannedStopPrice] = useState("");
 
   const { data: healthData } = useQuery({
     queryKey: ["market-status"],
@@ -342,8 +342,13 @@ export default function TradePlan() {
     staleTime: 60000,
   });
 
-  const regimeFromHealth =
-    healthData?.data?.regime_status || healthData?.regime_status || "";
+  const regimeFromHealth = (() => {
+    if (healthData?.data?.regime_status) return healthData.data.regime_status;
+    if (healthData?.regime_status) return healthData.regime_status;
+    const spy = healthData?.data?.spy;
+    if (spy != null) return spy.is_risk_on ? "risk_on" : "risk_off";
+    return "";
+  })();
 
   const { data: existingPlan, isLoading: loadingExisting } = useQuery({
     queryKey: ["tradePlan", editId],
@@ -368,6 +373,9 @@ export default function TradePlan() {
         entry_rationale: existingPlan.entry_rationale || "",
         regime_context_at_entry: existingPlan.regime_context_at_entry || "",
         r_target: existingPlan.r_target != null ? String(existingPlan.r_target) : "",
+        planned_quantity: existingPlan.planned_quantity != null ? String(existingPlan.planned_quantity) : "",
+        planned_entry_price: existingPlan.planned_entry_price != null ? String(existingPlan.planned_entry_price) : "",
+        planned_stop_price: existingPlan.planned_stop_price != null ? String(existingPlan.planned_stop_price) : "",
         early_exit_conditions: existingPlan.early_exit_conditions || "",
         confirmation_criteria: existingPlan.confirmation_criteria || "",
         checklist_items: checklistItems,
@@ -635,8 +643,8 @@ export default function TradePlan() {
         <Field label="Planned Shares (for pre-entry checks)">
           <TextInput
             type="number"
-            value={plannedQuantity}
-            onChange={(e) => setPlannedQuantity(e.target.value)}
+            value={form.planned_quantity}
+            onChange={set("planned_quantity")}
             placeholder="e.g. 50"
           />
         </Field>
@@ -645,8 +653,8 @@ export default function TradePlan() {
             <TextInput
               type="number"
               data-testid="planned-entry-price-input"
-              value={plannedEntryPrice}
-              onChange={(e) => setPlannedEntryPrice(e.target.value)}
+              value={form.planned_entry_price}
+              onChange={set("planned_entry_price")}
               placeholder="e.g. 150.00"
             />
           </Field>
@@ -654,8 +662,8 @@ export default function TradePlan() {
             <TextInput
               type="number"
               data-testid="planned-stop-price-input"
-              value={plannedStopPrice}
-              onChange={(e) => setPlannedStopPrice(e.target.value)}
+              value={form.planned_stop_price}
+              onChange={set("planned_stop_price")}
               placeholder="e.g. 142.00"
             />
           </Field>
@@ -663,9 +671,9 @@ export default function TradePlan() {
         <PreEntryValidationPanel
           ticker={form.ticker}
           market={form.market}
-          quantity={plannedQuantity}
-          entryPrice={plannedEntryPrice}
-          stopPrice={plannedStopPrice}
+          quantity={form.planned_quantity}
+          entryPrice={form.planned_entry_price}
+          stopPrice={form.planned_stop_price}
           overrideAcknowledged={form.pre_entry_override_acknowledged}
           onOverrideChange={(val) => setForm((prev) => ({ ...prev, pre_entry_override_acknowledged: val }))}
         />
@@ -717,6 +725,10 @@ export default function TradePlan() {
                           market: form.market,
                           setup_type: form.setup_type,
                           signal_data: linkedSignal || null,
+                          planned_entry_price: form.planned_entry_price !== "" ? parseFloat(form.planned_entry_price) : null,
+                          planned_stop_price: form.planned_stop_price !== "" ? parseFloat(form.planned_stop_price) : null,
+                          planned_quantity: form.planned_quantity !== "" ? parseInt(form.planned_quantity, 10) : null,
+                          r_target: form.r_target !== "" ? parseFloat(form.r_target) : null,
                         }),
                       });
                       const json = await res.json();


### PR DESCRIPTION
## Summary
- **Regime field fix**: `TradePlan.js` was reading `regime_status` from `/market/status` response but the endpoint returns `spy.is_risk_on` — field always showed blank. Now derives `risk_on`/`risk_off` from `spy.is_risk_on`.
- **Pre-entry fields now persist**: `planned_quantity`, `planned_entry_price`, `planned_stop_price` were ephemeral `useState` variables — lost on every save/reload. Moved into form state, added DB columns via idempotent migration, wired through Pydantic models and `update_trade_plan` allowed set.
- **AI generation uses real trade parameters**: `generate_full_plan` prompt previously had no knowledge of actual entry price, stop, quantity or R-target — producing generic rationale inconsistent with the real trade. Now receives and anchors on these values.
- **BLG-BE-25 filed**: pre-entry regime gate makes independent `yf.download` calls causing spurious risk_off failures when Yahoo Finance returns slightly different data on sequential calls.

## Test plan
- [ ] Open a new Trade Plan, fill in planned entry/stop/quantity, save — confirm fields survive reload
- [ ] Regime Context field auto-populates with `risk_on` or `risk_off` on Trade Plan page
- [ ] "Improve with AI" with entry/stop/quantity filled in produces rationale referencing actual prices
- [ ] Backend restarts cleanly with new `ensure_trade_plan_pre_entry_columns` migration logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)