### PR TITLE
[GOVERNANCE] Fix Positions review-settings link and signal 0-shares sizing bug

### DIFF
--- a/backend/services/signal_service.py
+++ b/backend/services/signal_service.py
@@ -364,17 +364,29 @@ def generate_momentum_signals(
     # Add position sizing to signals
     for signal in signals_sorted:
         if signal['status'] == 'new':
-            signal['allocation_gbp'] = round(allocation_per_stock, 2)
             signal['suggested_shares'] = int(allocation_per_stock / signal['price_gbp'])
 
-            # ST-06 (BLG-FEAT-43): flag signals where price exceeds allocation
+            # ST-06 (BLG-FEAT-43): flag signals where price exceeds allocation.
+            # If the capped allocation can't buy 1 share but total cash can, suggest 1
+            # share (oversized but actionable). Only mark insufficient when total cash
+            # is genuinely less than the price of 1 share.
             if signal['suggested_shares'] == 0:
-                signal['status'] = 'allocation_insufficient'
-                signal['reason'] = (
-                    f"1 share (£{signal['price_gbp']:,.0f}) exceeds position allocation "
-                    f"(£{allocation_per_stock:,.0f}) — cannot size"
-                )
+                if available_for_new >= signal['price_gbp']:
+                    signal['suggested_shares'] = 1
+                    signal['allocation_gbp'] = round(signal['price_gbp'], 2)
+                    signal['reason'] = (
+                        f"1 share sized above normal limit "
+                        f"(£{signal['price_gbp']:,.0f} vs £{allocation_per_stock:,.0f} allocation)"
+                    )
+                else:
+                    signal['allocation_gbp'] = round(allocation_per_stock, 2)
+                    signal['status'] = 'allocation_insufficient'
+                    signal['reason'] = (
+                        f"1 share (£{signal['price_gbp']:,.0f}) exceeds available cash "
+                        f"(£{available_for_new:,.0f}) — cannot size"
+                    )
             else:
+                signal['allocation_gbp'] = round(allocation_per_stock, 2)
                 signal['reason'] = None
 
             # Calculate fees

--- a/src/components/signals/SignalCard.js
+++ b/src/components/signals/SignalCard.js
@@ -152,6 +152,9 @@ export default function SignalCard({ signal, onAddToWatchlist, onDismiss, isAddi
               <p className="text-xs text-slate-400 mt-1">
                 Stop distance: <span className="text-rose-400 font-mono">{currencySymbol}{(signal.current_price - signal.initial_stop).toFixed(2)}</span>
               </p>
+              {signal.reason && (
+                <p className="text-xs text-amber-400/80 mt-2">⚠ {signal.reason}</p>
+              )}
             </div>
           </div>
         </motion.div>

--- a/src/pages/Positions.js
+++ b/src/pages/Positions.js
@@ -410,13 +410,13 @@ function ConcentrationLimitsWarning() {
           </ul>
         </div>
       )}
-      <a
-        href="/#/Settings"
+      <Link
+        to={createPageUrl("Settings")}
         className="mt-3 inline-block text-xs text-amber-700 underline hover:text-amber-900"
         aria-label="Review portfolio concentration limit settings"
       >
         Review Settings
-      </a>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

**Fix 1 — Positions page: Review Settings link**
Replaced a raw \`<a href="/#/Settings">\` anchor with React Router's \`<Link>\` in \`ConcentrationLimitsWarning\`. The old anchor caused a full page reload; it now navigates client-side.

**Fix 2 — Signals page: 0-shares sizing bug**
The per-signal allocation is capped at 20% of available cash. When 20% of cash was less than the price of 1 share, the signal was marked \`allocation_insufficient\` (0 shares) even if total cash was sufficient to buy the stock. Now: if total cash ≥ price of 1 share, the signal suggests 1 share with an amber warning note; 0 shares only when total cash is genuinely less than 1 share.

**Fix 3 — Settings page: Add concentration limit controls**
The concentration-status endpoint already read \`concentration_position_threshold_pct\` and \`concentration_sector_threshold_pct\` from the settings table, but those columns didn't exist and the Settings UI had no fields for them. Added:
- DB migration (\`ensure_settings_concentration_columns\`) to add both columns — runs at startup
- Both fields added to \`SettingsRequest\` so the API accepts them
- New "Risk Limits" section in the Settings page (position threshold default 15%, sector threshold default 30%)

## Files changed

- \`src/pages/Positions.js\` — \`<a>\` → \`<Link>\` in \`ConcentrationLimitsWarning\`
- \`src/components/signals/SignalCard.js\` — display \`signal.reason\` note for new signals
- \`backend/services/signal_service.py\` — fix \`suggested_shares\` fallback to 1 when cash is sufficient
- \`backend/database.py\` — add \`ensure_settings_concentration_columns\` migration
- \`backend/main.py\` — call migration at startup
- \`backend/models/requests.py\` — add concentration fields to \`SettingsRequest\`
- \`src/pages/Settings.js\` — add Risk Limits section with position/sector threshold inputs

## Test plan

- [ ] Navigate to Positions page with a concentration breach active — click "Review Settings" and confirm it routes to Settings without a page reload
- [ ] On the Settings page, confirm the Risk Limits section is visible with Position and Sector threshold fields; change values, save, and confirm the concentration warning on Positions reflects the new thresholds after regenerating
- [ ] Regenerate signals where 20% of cash < price of the most expensive signal stock but total cash ≥ that price — confirm it shows 1 share with the amber "sized above normal limit" note instead of "Cannot Size"
- [ ] Confirm a signal where total cash < price of 1 share still correctly shows "Cannot Size" / 0 shares

🤖 Generated with [Claude Code](https://claude.com/claude-code)