### PR TITLE
[GOVERNANCE] Add concentration limit settings to Settings page

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1312,6 +1312,25 @@ def ensure_trade_plan_pre_entry_columns():
         conn.commit()
 
 
+def ensure_settings_concentration_columns():
+    """Add concentration threshold columns to settings (idempotent).
+
+    Allows users to configure position and sector concentration limits
+    via the Settings page rather than relying on hardcoded defaults.
+    """
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "ALTER TABLE settings ADD COLUMN IF NOT EXISTS "
+                "concentration_position_threshold_pct NUMERIC(5, 2)"
+            )
+            cur.execute(
+                "ALTER TABLE settings ADD COLUMN IF NOT EXISTS "
+                "concentration_sector_threshold_pct NUMERIC(5, 2)"
+            )
+        conn.commit()
+
+
 def get_trade_by_id(trade_id: str) -> Optional[Dict]:
     """Fetch a single trade_history record by its UUID."""
     with get_db() as conn:

--- a/backend/main.py
+++ b/backend/main.py
@@ -311,6 +311,12 @@ def on_startup():
     except Exception as _e:
         _log.error("ensure_trade_plan_pre_entry_columns FAILED at startup: %s", _e)
     try:
+        from database import ensure_settings_concentration_columns
+        ensure_settings_concentration_columns()
+        _log.info("ensure_settings_concentration_columns: OK")
+    except Exception as _e:
+        _log.error("ensure_settings_concentration_columns FAILED at startup: %s", _e)
+    try:
         from utils.feature_flags import log_flag_states
         log_flag_states()
     except Exception as _e:

--- a/backend/models/requests.py
+++ b/backend/models/requests.py
@@ -41,6 +41,8 @@ class SettingsRequest(BaseModel):
     fx_fee_rate: Optional[float] = None
     min_trades_for_analytics: Optional[int] = None
     default_risk_percent: Optional[float] = None
+    concentration_position_threshold_pct: Optional[float] = None
+    concentration_sector_threshold_pct: Optional[float] = None
 
     @validator('default_risk_percent')
     def validate_default_risk_percent(cls, v):

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -7,7 +7,7 @@ import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
 import PageHeader from "../components/ui/PageHeader";
-import { Save, Loader2, CheckCircle2, Sliders, CreditCard, Palette, TrendingUp } from "lucide-react";
+import { Save, Loader2, CheckCircle2, Sliders, CreditCard, Palette, TrendingUp, ShieldAlert } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "../lib/utils";
 
@@ -35,6 +35,8 @@ export default function Settings() {
     stamp_duty_rate: 0.005,
     fx_fee_rate: 0.0015,
     min_trades_for_analytics: 10,
+    concentration_position_threshold_pct: 15,
+    concentration_sector_threshold_pct: 30,
   };
 
   // Dependency array is [settings] only — adding formData causes an infinite loop
@@ -337,6 +339,44 @@ export default function Settings() {
                 <SelectItem value="light">Light</SelectItem>
               </SelectContent>
             </Select>
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* Risk Limits */}
+      <SectionCard
+        icon={ShieldAlert}
+        title="Risk Limits"
+        iconColor="bg-amber-500/20 text-amber-400"
+      >
+        <div className="space-y-6">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label className="text-slate-400">Position Concentration Limit (%)</Label>
+              <Input
+                type="number"
+                step="1"
+                min="1"
+                max="100"
+                value={formData.concentration_position_threshold_pct ?? 15}
+                onChange={(e) => handleChange("concentration_position_threshold_pct", parseFloat(e.target.value))}
+                className="bg-slate-800/50 border-slate-700 text-white"
+              />
+              <p className="text-xs text-slate-500">Alert when 1 position exceeds this % of total portfolio heat (default: 15%)</p>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-slate-400">Sector Concentration Limit (%)</Label>
+              <Input
+                type="number"
+                step="1"
+                min="1"
+                max="100"
+                value={formData.concentration_sector_threshold_pct ?? 30}
+                onChange={(e) => handleChange("concentration_sector_threshold_pct", parseFloat(e.target.value))}
+                className="bg-slate-800/50 border-slate-700 text-white"
+              />
+              <p className="text-xs text-slate-500">Alert when 1 sector exceeds this % of total portfolio heat (default: 30%)</p>
+            </div>
           </div>
         </div>
       </SectionCard>


### PR DESCRIPTION
## Summary

The concentration-status endpoint already read `concentration_position_threshold_pct` and `concentration_sector_threshold_pct` from the settings table, but those columns didn't exist and the Settings UI had no fields for them — so the thresholds were always the hardcoded defaults (15% position, 30% sector) with no way to change them.

- **DB migration** (`ensure_settings_concentration_columns`) adds both columns to the `settings` table; runs idempotently at startup
- **`SettingsRequest`** updated to accept both fields so `PATCH /settings/{id}` persists them
- **Settings page** gains a new "Risk Limits" section with position threshold (default 15%) and sector threshold (default 30%) inputs

## Files changed

- `backend/database.py` — `ensure_settings_concentration_columns` migration
- `backend/main.py` — call migration at startup
- `backend/models/requests.py` — add concentration fields to `SettingsRequest`
- `src/pages/Settings.js` — add Risk Limits section with position/sector threshold inputs

## Test plan

- [ ] Load Settings page — confirm "Risk Limits" section is visible with two numeric inputs pre-filled at 15% and 30%
- [ ] Change position threshold to 10%, save — navigate to Positions and confirm the concentration warning fires at the new threshold
- [ ] Change sector threshold to 25%, save — confirm sector breach alert uses the updated value

🤖 Generated with [Claude Code](https://claude.com/claude-code)