### PR TITLE
[GOVERNANCE] Fix trade_plans status constraint to include all workflow statuses

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1795,6 +1795,29 @@ def ensure_si05_digest_log_table() -> None:
         conn.commit()
 
 
+def ensure_trade_plans_extended_status() -> None:
+    """Extend trade_plans_status_check to include workflow statuses (idempotent).
+
+    The original constraint only allowed ('draft', 'active', 'closed').
+    The frontend workflow uses additional statuses: research_pending,
+    research_complete, entry_conditions_set, abandoned.
+    """
+    full_statuses = (
+        "'draft', 'research_pending', 'research_complete', "
+        "'entry_conditions_set', 'active', 'closed', 'abandoned'"
+    )
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "ALTER TABLE trade_plans DROP CONSTRAINT IF EXISTS trade_plans_status_check"
+            )
+            cur.execute(
+                f"ALTER TABLE trade_plans ADD CONSTRAINT trade_plans_status_check "
+                f"CHECK (status IN ({full_statuses}))"
+            )
+        conn.commit()
+
+
 def get_behavioural_drift_data(portfolio_id: str, window_days: int = 90) -> dict:
     """Fetch all data needed for SI-02 drift metric computation.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -323,6 +323,12 @@ def on_startup():
     except Exception as _e:
         _log.error("ensure_si05_digest_log_table FAILED at startup: %s", _e)
     try:
+        from database import ensure_trade_plans_extended_status
+        ensure_trade_plans_extended_status()
+        _log.info("ensure_trade_plans_extended_status: OK")
+    except Exception as _e:
+        _log.error("ensure_trade_plans_extended_status FAILED at startup: %s", _e)
+    try:
         from utils.feature_flags import log_flag_states
         log_flag_states()
     except Exception as _e:


### PR DESCRIPTION
## Summary
- DB `trade_plans_status_check` constraint only allowed `draft`, `active`, `closed` but the frontend workflow sends `entry_conditions_set` (and also `research_pending`, `research_complete`, `abandoned`), causing a hard constraint violation on save
- Adds `ensure_trade_plans_extended_status()` migration in `database.py` that drops and recreates the constraint with all 7 valid statuses
- Registers the migration in `main.py` startup sequence — idempotent, safe to run on live DB

## Test plan
- [ ] Restart backend and confirm `ensure_trade_plans_extended_status: OK` in logs
- [ ] Enter a new trade plan and confirm it saves without constraint error
- [ ] Verify existing plans with `draft`/`active`/`closed` status are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)